### PR TITLE
adding content_type as an argument to get functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: The package wraps the mailchimp api and aims to provide easy access
 License: MIT
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1
 Imports:
   httr,
   stringr,

--- a/R/GET_lists.R
+++ b/R/GET_lists.R
@@ -6,6 +6,7 @@
 #'
 #' @param apikey API key for mailchimp account
 #' @param user User to use in authentication. Can be any string you like. Defaults to "anystring".
+#' @param content_type MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.
 #' @param ... Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/#}{API documentation}.
 #' @return Response body parameters. See response parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/#}{API documentation}.
 #'
@@ -19,6 +20,7 @@
 
 get_lists <- function(apikey = NULL,
                       user = "anystring",
+                      content_type = "application/json",
                       ...){
 
   # Sanity check
@@ -35,7 +37,7 @@ get_lists <- function(apikey = NULL,
                        httr::authenticate(user, apikey))
 
   # Convert the response to JSON
-  GETdata <- httr::content(GETdata, type = "application/json")
+  GETdata <- httr::content(GETdata, type = content_type)
 
   # Return data
   return(GETdata)
@@ -52,6 +54,7 @@ get_lists <- function(apikey = NULL,
 #' @param list_id The unique id for the list. Find the list id with \code{\link{get_lists}}
 #' @param apikey API key for mailchimp account
 #' @param user User to use in authentication. Can be any string you like. Defaults to "anystring".
+#' @param content_type MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.
 #' @param ... Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/#}{API documentation}.
 #' @return Response body parameters. See response parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/#}{API documentation}.
 #'
@@ -66,6 +69,7 @@ get_lists <- function(apikey = NULL,
 get_list <- function(list_id = NULL,
                      apikey = NULL,
                      user = "anystring",
+                     content_type = "application/json",
                      ...){
 
   # Sanity check
@@ -83,7 +87,7 @@ get_list <- function(list_id = NULL,
                        httr::authenticate(user, apikey))
 
   # Convert the response to JSON
-  GETdata <- httr::content(GETdata, type = "application/json")
+  GETdata <- httr::content(GETdata, type = content_type)
 
   # Return data
   return(GETdata)
@@ -100,6 +104,7 @@ get_list <- function(list_id = NULL,
 #' @param list_id The unique id for the list. Find the list id with \code{\link{get_lists}}
 #' @param apikey API key for mailchimp account
 #' @param user User to use in authentication. Can be any string you like. Defaults to "anystring".
+#' @param content_type MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.
 #' @param ... Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#}{API documentation}.
 #' @return Response body parameters. See response parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#}{API documentation}.
 #'
@@ -114,6 +119,7 @@ get_list <- function(list_id = NULL,
 get_list_members <- function(list_id = NULL,
                      apikey = NULL,
                      user = "anystring",
+                     content_type = "application/json",
                      ...){
 
   # Sanity check
@@ -131,7 +137,7 @@ get_list_members <- function(list_id = NULL,
                        httr::authenticate(user, apikey))
 
   # Convert the response to JSON
-  GETdata <- httr::content(GETdata, type = "application/json")
+  GETdata <- httr::content(GETdata, type = content_type)
 
   # Return data
   return(GETdata)
@@ -148,6 +154,7 @@ get_list_members <- function(list_id = NULL,
 #' @param subscriber_hash The MD5 hash of the lowercase version of the list member’s email address.
 #' @param apikey API key for mailchimp account.
 #' @param user User to use in authentication. Can be any string you like. Defaults to "anystring".
+#' @param content_type MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.
 #' @param ... Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#}{API documentation}.
 #' @return Response body parameters. See response parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#}{API documentation}.
 #'
@@ -160,9 +167,10 @@ get_list_members <- function(list_id = NULL,
 #' @export
 get_list_member <- function(list_id = NULL,
                             subscriber_hash = NULL,
-                             apikey = NULL,
-                             user = "anystring",
-                             ...){
+                            apikey = NULL,
+                            user = "anystring",
+                            content_type = "application/json",
+                            ...){
 
   # Sanity check
   if(is.null(apikey)) stop("API key is missing")
@@ -180,7 +188,7 @@ get_list_member <- function(list_id = NULL,
                        httr::authenticate(user, apikey))
 
   # Convert the response to JSON
-  GETdata <- httr::content(GETdata, type = "application/json")
+  GETdata <- httr::content(GETdata, type = content_type)
 
   # Return data
   return(GETdata)
@@ -197,6 +205,7 @@ get_list_member <- function(list_id = NULL,
 #' @param subscriber_hash The MD5 hash of the lowercase version of the list member’s email address.
 #' @param apikey API key for mailchimp account.
 #' @param user User to use in authentication. Can be any string you like. Defaults to "anystring".
+#' @param content_type MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.
 #' @param ... Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/activity/}{API documentation}.
 #' @return Response body parameters. See response parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/activity/}{API documentation}.
 #'
@@ -211,6 +220,7 @@ get_list_member_activity <- function(list_id = NULL,
                             subscriber_hash = NULL,
                             apikey = NULL,
                             user = "anystring",
+                            content_type = "application/json",
                             ...){
 
   # Sanity check
@@ -229,7 +239,7 @@ get_list_member_activity <- function(list_id = NULL,
                        httr::authenticate(user, apikey))
 
   # Convert the response to JSON
-  GETdata <- httr::content(GETdata, type = "application/json")
+  GETdata <- httr::content(GETdata, type = content_type)
 
   # Return data
   return(GETdata)
@@ -246,6 +256,7 @@ get_list_member_activity <- function(list_id = NULL,
 #' @param subscriber_hash The MD5 hash of the lowercase version of the list member’s email address.
 #' @param apikey API key for mailchimp account.
 #' @param user User to use in authentication. Can be any string you like. Defaults to "anystring".
+#' @param content_type MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.
 #' @param ... Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/goals/}{API documentation}.
 #' @return Response body parameters. See response parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/goals/}{API documentation}.
 #'
@@ -260,6 +271,7 @@ get_list_member_goals <- function(list_id = NULL,
                                      subscriber_hash = NULL,
                                      apikey = NULL,
                                      user = "anystring",
+                                     content_type = "application/json",
                                      ...){
 
   # Sanity check
@@ -278,7 +290,7 @@ get_list_member_goals <- function(list_id = NULL,
                        httr::authenticate(user, apikey))
 
   # Convert the response to JSON
-  GETdata <- httr::content(GETdata, type = "application/json")
+  GETdata <- httr::content(GETdata, type = content_type)
 
   # Return data
   return(GETdata)
@@ -295,6 +307,7 @@ get_list_member_goals <- function(list_id = NULL,
 #' @param subscriber_hash The MD5 hash of the lowercase version of the list member’s email address.
 #' @param apikey API key for mailchimp account.
 #' @param user User to use in authentication. Can be any string you like. Defaults to "anystring".
+#' @param content_type MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.
 #' @param ... Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/notes/}{API documentation}.
 #' @return Response body parameters. See response parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/notes/}{API documentation}.
 #'
@@ -309,6 +322,7 @@ get_list_member_notes <- function(list_id = NULL,
                                   subscriber_hash = NULL,
                                   apikey = NULL,
                                   user = "anystring",
+                                  content_type = "application/json",
                                   ...){
 
   # Sanity check
@@ -327,7 +341,7 @@ get_list_member_notes <- function(list_id = NULL,
                        httr::authenticate(user, apikey))
 
   # Convert the response to JSON
-  GETdata <- httr::content(GETdata, type = "application/json")
+  GETdata <- httr::content(GETdata, type = content_type)
 
   # Return data
   return(GETdata)
@@ -345,6 +359,7 @@ get_list_member_notes <- function(list_id = NULL,
 #' @param note_id The id for the note.
 #' @param apikey API key for mailchimp account.
 #' @param user User to use in authentication. Can be any string you like. Defaults to "anystring".
+#' @param content_type MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.
 #' @param ... Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/notes/}{API documentation}.
 #' @return Response body parameters. See response parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/notes/}{API documentation}.
 #'
@@ -359,6 +374,7 @@ get_list_member_note <- function(list_id = NULL,
                                   subscriber_hash = NULL,
                                   apikey = NULL,
                                   user = "anystring",
+                                  content_type = "application/json",
                                   ...){
 
   # Sanity check
@@ -377,7 +393,7 @@ get_list_member_note <- function(list_id = NULL,
                        httr::authenticate(user, apikey))
 
   # Convert the response to JSON
-  GETdata <- httr::content(GETdata, type = "application/json")
+  GETdata <- httr::content(GETdata, type = content_type)
 
   # Return data
   return(GETdata)
@@ -393,6 +409,7 @@ get_list_member_note <- function(list_id = NULL,
 #' @param list_id The unique id for the list. Find the list id with \code{\link{get_lists}}
 #' @param apikey API key for mailchimp account
 #' @param user User to use in authentication. Can be any string you like. Defaults to "anystring".
+#' @param content_type MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.
 #' @param ... Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/#}{API documentation}.
 #' @return Response body parameters. See response parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/#}{API documentation}.
 #'
@@ -407,6 +424,7 @@ get_list_member_note <- function(list_id = NULL,
 get_list_segments <- function(list_id = NULL,
                              apikey = NULL,
                              user = "anystring",
+                             content_type = "application/json",
                              ...){
 
   # Sanity check
@@ -424,7 +442,7 @@ get_list_segments <- function(list_id = NULL,
                        httr::authenticate(user, apikey))
 
   # Convert the response to JSON
-  GETdata <- httr::content(GETdata, type = "application/json")
+  GETdata <- httr::content(GETdata, type = content_type)
 
   # Return data
   return(GETdata)
@@ -441,6 +459,7 @@ get_list_segments <- function(list_id = NULL,
 #' @param segment_id The unique id for the segment.
 #' @param apikey API key for mailchimp account
 #' @param user User to use in authentication. Can be any string you like. Defaults to "anystring".
+#' @param content_type MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.
 #' @param ... Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/#}{API documentation}.
 #' @return Response body parameters. See response parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/#}{API documentation}.
 #'
@@ -455,6 +474,7 @@ get_list_segment <- function(list_id = NULL,
                               segment_id = NULL,
                               apikey = NULL,
                               user = "anystring",
+                              content_type = "application/json",
                               ...){
 
   # Sanity check
@@ -473,7 +493,7 @@ get_list_segment <- function(list_id = NULL,
                        httr::authenticate(user, apikey))
 
   # Convert the response to JSON
-  GETdata <- httr::content(GETdata, type = "application/json")
+  GETdata <- httr::content(GETdata, type = content_type)
 
   # Return data
   return(GETdata)
@@ -490,6 +510,7 @@ get_list_segment <- function(list_id = NULL,
 #' @param segment_id The unique id for the segment.
 #' @param apikey API key for mailchimp account
 #' @param user User to use in authentication. Can be any string you like. Defaults to "anystring".
+#' @param content_type MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.
 #' @param ... Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/#}{API documentation}.
 #' @return Response body parameters. See response parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/#}{API documentation}.
 #'
@@ -504,6 +525,7 @@ get_list_segment_members <- function(list_id = NULL,
                               segment_id = NULL,
                               apikey = NULL,
                               user = "anystring",
+                              content_type = "application/json",
                               ...){
 
   # Sanity check
@@ -522,7 +544,7 @@ get_list_segment_members <- function(list_id = NULL,
                        httr::authenticate(user, apikey))
 
   # Convert the response to JSON
-  GETdata <- httr::content(GETdata, type = "application/json")
+  GETdata <- httr::content(GETdata, type = content_type)
 
   # Return data
   return(GETdata)

--- a/man/apiending.Rd
+++ b/man/apiending.Rd
@@ -21,4 +21,3 @@ Is a helperfunction to extract the server that needs to be called in the api cal
 apiending(apikey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-usxx")
 ## End(**Not run**)
 }
-

--- a/man/get_list.Rd
+++ b/man/get_list.Rd
@@ -4,7 +4,8 @@
 \alias{get_list}
 \title{Get information about a specific list}
 \usage{
-get_list(list_id = NULL, apikey = NULL, user = "anystring", ...)
+get_list(list_id = NULL, apikey = NULL, user = "anystring",
+  content_type = "application/json", ...)
 }
 \arguments{
 \item{list_id}{The unique id for the list. Find the list id with \code{\link{get_lists}}}
@@ -12,6 +13,8 @@ get_list(list_id = NULL, apikey = NULL, user = "anystring", ...)
 \item{apikey}{API key for mailchimp account}
 
 \item{user}{User to use in authentication. Can be any string you like. Defaults to "anystring".}
+
+\item{content_type}{MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.}
 
 \item{...}{Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/#}{API documentation}.}
 }
@@ -28,4 +31,3 @@ mylist <- get_list(apikey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-usxx", list_id = "
 ## End(**Not run**)
 
 }
-

--- a/man/get_list_member.Rd
+++ b/man/get_list_member.Rd
@@ -5,7 +5,7 @@
 \title{Get information about a specific list member}
 \usage{
 get_list_member(list_id = NULL, subscriber_hash = NULL, apikey = NULL,
-  user = "anystring", ...)
+  user = "anystring", content_type = "application/json", ...)
 }
 \arguments{
 \item{list_id}{The unique id for the list. Find the list id with \code{\link{get_lists}}.}
@@ -15,6 +15,8 @@ get_list_member(list_id = NULL, subscriber_hash = NULL, apikey = NULL,
 \item{apikey}{API key for mailchimp account.}
 
 \item{user}{User to use in authentication. Can be any string you like. Defaults to "anystring".}
+
+\item{content_type}{MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.}
 
 \item{...}{Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#}{API documentation}.}
 }
@@ -31,4 +33,3 @@ mymember <- get_list_member(apikey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-usxx", li
 ## End(**Not run**)
 
 }
-

--- a/man/get_list_member_activity.Rd
+++ b/man/get_list_member_activity.Rd
@@ -5,7 +5,8 @@
 \title{Get recent list member activity}
 \usage{
 get_list_member_activity(list_id = NULL, subscriber_hash = NULL,
-  apikey = NULL, user = "anystring", ...)
+  apikey = NULL, user = "anystring", content_type = "application/json",
+  ...)
 }
 \arguments{
 \item{list_id}{The unique id for the list. Find the list id with \code{\link{get_lists}}.}
@@ -15,6 +16,8 @@ get_list_member_activity(list_id = NULL, subscriber_hash = NULL,
 \item{apikey}{API key for mailchimp account.}
 
 \item{user}{User to use in authentication. Can be any string you like. Defaults to "anystring".}
+
+\item{content_type}{MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.}
 
 \item{...}{Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/activity/}{API documentation}.}
 }
@@ -31,4 +34,3 @@ mymember_activity <- get_list_member_activity(apikey = "xxxxxxxxxxxxxxxxxxxxxxxx
 ## End(**Not run**)
 
 }
-

--- a/man/get_list_member_goals.Rd
+++ b/man/get_list_member_goals.Rd
@@ -5,7 +5,8 @@
 \title{Get the last 50 Goal events for a member on a specific list}
 \usage{
 get_list_member_goals(list_id = NULL, subscriber_hash = NULL,
-  apikey = NULL, user = "anystring", ...)
+  apikey = NULL, user = "anystring", content_type = "application/json",
+  ...)
 }
 \arguments{
 \item{list_id}{The unique id for the list. Find the list id with \code{\link{get_lists}}.}
@@ -15,6 +16,8 @@ get_list_member_goals(list_id = NULL, subscriber_hash = NULL,
 \item{apikey}{API key for mailchimp account.}
 
 \item{user}{User to use in authentication. Can be any string you like. Defaults to "anystring".}
+
+\item{content_type}{MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.}
 
 \item{...}{Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/goals/}{API documentation}.}
 }
@@ -31,4 +34,3 @@ mymember_goals <- get_list_member_goals(apikey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ## End(**Not run**)
 
 }
-

--- a/man/get_list_member_note.Rd
+++ b/man/get_list_member_note.Rd
@@ -5,7 +5,8 @@
 \title{Get recent notes for a specific list member}
 \usage{
 get_list_member_note(list_id = NULL, subscriber_hash = NULL,
-  apikey = NULL, user = "anystring", ...)
+  apikey = NULL, user = "anystring", content_type = "application/json",
+  ...)
 }
 \arguments{
 \item{list_id}{The unique id for the list. Find the list id with \code{\link{get_lists}}.}
@@ -15,6 +16,8 @@ get_list_member_note(list_id = NULL, subscriber_hash = NULL,
 \item{apikey}{API key for mailchimp account.}
 
 \item{user}{User to use in authentication. Can be any string you like. Defaults to "anystring".}
+
+\item{content_type}{MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.}
 
 \item{...}{Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/notes/}{API documentation}.}
 
@@ -33,4 +36,3 @@ mymember_note <- get_list_member_note(apikey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ## End(**Not run**)
 
 }
-

--- a/man/get_list_member_notes.Rd
+++ b/man/get_list_member_notes.Rd
@@ -5,7 +5,8 @@
 \title{Get recent notes for a specific list member}
 \usage{
 get_list_member_notes(list_id = NULL, subscriber_hash = NULL,
-  apikey = NULL, user = "anystring", ...)
+  apikey = NULL, user = "anystring", content_type = "application/json",
+  ...)
 }
 \arguments{
 \item{list_id}{The unique id for the list. Find the list id with \code{\link{get_lists}}.}
@@ -15,6 +16,8 @@ get_list_member_notes(list_id = NULL, subscriber_hash = NULL,
 \item{apikey}{API key for mailchimp account.}
 
 \item{user}{User to use in authentication. Can be any string you like. Defaults to "anystring".}
+
+\item{content_type}{MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.}
 
 \item{...}{Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/notes/}{API documentation}.}
 }
@@ -31,4 +34,3 @@ mymember_notes <- get_list_member_notes(apikey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ## End(**Not run**)
 
 }
-

--- a/man/get_list_members.Rd
+++ b/man/get_list_members.Rd
@@ -4,7 +4,8 @@
 \alias{get_list_members}
 \title{Get information about members in a list}
 \usage{
-get_list_members(list_id = NULL, apikey = NULL, user = "anystring", ...)
+get_list_members(list_id = NULL, apikey = NULL, user = "anystring",
+  content_type = "application/json", ...)
 }
 \arguments{
 \item{list_id}{The unique id for the list. Find the list id with \code{\link{get_lists}}}
@@ -12,6 +13,8 @@ get_list_members(list_id = NULL, apikey = NULL, user = "anystring", ...)
 \item{apikey}{API key for mailchimp account}
 
 \item{user}{User to use in authentication. Can be any string you like. Defaults to "anystring".}
+
+\item{content_type}{MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.}
 
 \item{...}{Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#}{API documentation}.}
 }
@@ -28,4 +31,3 @@ mymembers <- get_list_members(apikey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-usxx", 
 ## End(**Not run**)
 
 }
-

--- a/man/get_list_segment.Rd
+++ b/man/get_list_segment.Rd
@@ -5,7 +5,7 @@
 \title{Get information about a specific segment}
 \usage{
 get_list_segment(list_id = NULL, segment_id = NULL, apikey = NULL,
-  user = "anystring", ...)
+  user = "anystring", content_type = "application/json", ...)
 }
 \arguments{
 \item{list_id}{The unique id for the list. Find the list id with \code{\link{get_lists}}.}
@@ -15,6 +15,8 @@ get_list_segment(list_id = NULL, segment_id = NULL, apikey = NULL,
 \item{apikey}{API key for mailchimp account}
 
 \item{user}{User to use in authentication. Can be any string you like. Defaults to "anystring".}
+
+\item{content_type}{MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.}
 
 \item{...}{Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/#}{API documentation}.}
 }
@@ -31,4 +33,3 @@ mysegment <- get_list_segment(apikey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-usxx", 
 ## End(**Not run**)
 
 }
-

--- a/man/get_list_segment_members.Rd
+++ b/man/get_list_segment_members.Rd
@@ -5,7 +5,7 @@
 \title{Get information about all members in a list segment}
 \usage{
 get_list_segment_members(list_id = NULL, segment_id = NULL, apikey = NULL,
-  user = "anystring", ...)
+  user = "anystring", content_type = "application/json", ...)
 }
 \arguments{
 \item{list_id}{The unique id for the list. Find the list id with \code{\link{get_lists}}.}
@@ -15,6 +15,8 @@ get_list_segment_members(list_id = NULL, segment_id = NULL, apikey = NULL,
 \item{apikey}{API key for mailchimp account}
 
 \item{user}{User to use in authentication. Can be any string you like. Defaults to "anystring".}
+
+\item{content_type}{MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.}
 
 \item{...}{Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/#}{API documentation}.}
 }
@@ -31,4 +33,3 @@ mysegment_members <- get_list_segment_members(apikey = "xxxxxxxxxxxxxxxxxxxxxxxx
 ## End(**Not run**)
 
 }
-

--- a/man/get_list_segments.Rd
+++ b/man/get_list_segments.Rd
@@ -4,7 +4,8 @@
 \alias{get_list_segments}
 \title{Get information about all segments in a list}
 \usage{
-get_list_segments(list_id = NULL, apikey = NULL, user = "anystring", ...)
+get_list_segments(list_id = NULL, apikey = NULL, user = "anystring",
+  content_type = "application/json", ...)
 }
 \arguments{
 \item{list_id}{The unique id for the list. Find the list id with \code{\link{get_lists}}}
@@ -12,6 +13,8 @@ get_list_segments(list_id = NULL, apikey = NULL, user = "anystring", ...)
 \item{apikey}{API key for mailchimp account}
 
 \item{user}{User to use in authentication. Can be any string you like. Defaults to "anystring".}
+
+\item{content_type}{MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.}
 
 \item{...}{Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/#}{API documentation}.}
 }
@@ -28,4 +31,3 @@ mysegments <- get_list_segments(apikey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-usxx"
 ## End(**Not run**)
 
 }
-

--- a/man/get_lists.Rd
+++ b/man/get_lists.Rd
@@ -4,12 +4,15 @@
 \alias{get_lists}
 \title{Get information about all lists}
 \usage{
-get_lists(apikey = NULL, user = "anystring", ...)
+get_lists(apikey = NULL, user = "anystring",
+  content_type = "application/json", ...)
 }
 \arguments{
 \item{apikey}{API key for mailchimp account}
 
 \item{user}{User to use in authentication. Can be any string you like. Defaults to "anystring".}
+
+\item{content_type}{MIME type (aka internet media type) used to override the content type returned by the server. See \url{http://en.wikipedia.org/wiki/Internet_media_type} for a list of common types.}
 
 \item{...}{Query string parameters. See available parameters under READ here: \href{https://developer.mailchimp.com/documentation/mailchimp/reference/lists/#}{API documentation}.}
 }
@@ -26,4 +29,3 @@ mylists <- get_lists(apikey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-usxx")
 ## End(**Not run**)
 
 }
-

--- a/man/post_segment.Rd
+++ b/man/post_segment.Rd
@@ -31,4 +31,3 @@ post_segment <- post_segment(name = "my_new_segment", static_segment = c("e@mail
 ## End(**Not run**)
 
 }
-

--- a/man/post_segment_members.Rd
+++ b/man/post_segment_members.Rd
@@ -34,4 +34,3 @@ post_segment_members <- post_segment_members(list_id = "xxxxxxxxxx", members_to_
 ## End(**Not run**)
 
 }
-


### PR DESCRIPTION
I like the option of being able to extract the content as `type = 'text'`. This makes it easy to pass to `jsonlite::fromJSON()` and get output that's a little easier to wrangle into rectangular form. 